### PR TITLE
feat: implement fl destroy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,23 @@ fl update <app>         # Update a deployed app
 fl stop <app>           # Stop an app
 fl start <app>          # Start a stopped app
 fl restart <app>        # Restart an app
-fl destroy <app>        # Remove an app completely
 fl status               # Show status of all apps
 ```
+
+### Destroy App
+
+```bash
+fl destroy <app>              # Interactive confirmation (type app name)
+fl destroy <app> --keep-data  # Keep database/cache volumes
+fl destroy <app> --force      # Skip confirmation (for scripting)
+fl destroy <app> -y           # Same as --force
+```
+
+The destroy command:
+- Requires typing the app name to confirm (safety)
+- Asks whether to delete data volumes
+- Removes containers, network, Traefik config, images
+- Warns if app is currently running
 
 ### Logs
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -79,6 +79,14 @@ pub enum Commands {
     Destroy {
         /// Name of the app to destroy
         app: String,
+
+        /// Skip confirmation prompt (for scripting)
+        #[arg(long, short = 'y')]
+        force: bool,
+
+        /// Keep database and cache volumes (preserve data)
+        #[arg(long)]
+        keep_data: bool,
     },
 
     /// Rollback to a previous deployment

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,8 +73,8 @@ fn run_command(command: Commands, verbose: bool) -> Result<()> {
             Ok(())
         }
 
-        Commands::Destroy { app } => {
-            flaase::cli::deploy::destroy(&app, verbose)?;
+        Commands::Destroy { app, force, keep_data } => {
+            flaase::cli::deploy::destroy(&app, force, keep_data, verbose)?;
             Ok(())
         }
 


### PR DESCRIPTION
## Description

Implement the `fl destroy <app>` command to completely remove an app and all its resources. This includes safety confirmations to prevent accidental deletion.

## Related Issue

Closes #9

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] CI/Build changes
- [ ] Chore (maintenance, dependencies, etc.)

## Changes Made

- Add `fl destroy <app>` command implementation
- Require typing exact app name for confirmation
- Option to delete or keep database/cache volumes
- Stop and remove app container
- Optionally remove database/cache containers and volumes
- Remove Traefik routing config
- Remove app directory from `/opt/flaase/apps/`
- Remove Docker network
- Add `--force` flag to skip confirmation (for scripting)
- Warning if app is currently running
- Progress bars for each cleanup step

## Screenshots / Recordings
```
$ fl destroy my-app

   __ _
  / _| | __ _  __ _ ___  ___
 | |_| |/ _` |/ _` / __|/ _ \
 |  _| | (_| | (_| \__ \  __/
 |_| |_|\__,_|\__,_|___/\___|

! Warning: App 'my-app' is currently running

┌ Are you sure? Type "my-app" to confirm ──────────────┐
│ my-app                                               │
└──────────────────────────────────────────────────────┘

┌ Also delete database and volumes? ───────────────────┐
│ › ● Yes, delete everything                           │
│   ○ No, keep data                                    │
└──────────────────────────────────────────────────────┘

Stopping containers   ████████████████████ 100%
Removing volumes      ████████████████████ 100%
Removing network      ████████████████████ 100%
Removing config       ████████████████████ 100%
Cleaning up           ████████████████████ 100%

✓ App destroyed

$ fl destroy my-app --force

Stopping containers   ████████████████████ 100%
Removing volumes      ████████████████████ 100%
Removing network      ████████████████████ 100%
Removing config       ████████████████████ 100%
Cleaning up           ████████████████████ 100%

✓ App destroyed

$ fl destroy my-app

┌ Are you sure? Type "my-app" to confirm ──────────────┐
│ myapp                                                │
└──────────────────────────────────────────────────────┘

✗ Confirmation does not match. Aborting.
```

## How Has This Been Tested?

- [ ] Unit tests pass (`cargo test`)
- [ ] Integration tests pass
- [x] Manual testing performed
- [x] Tested on Linux
- [ ] Tested on macOS

### Test Configuration

- **OS:** Ubuntu 24.04
- **Rust version:** 1.75+
- **Target server OS:** Ubuntu 24.04 (OVH VPS)

## Checklist

### Code Quality
- [x] My code follows the project's code style
- [x] I have run `cargo fmt` and `cargo clippy`
- [ ] I have added/updated tests for my changes
- [x] All new and existing tests pass

### Documentation
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (if applicable)
- [x] I have added rustdoc comments to public APIs

### PR Quality
- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] This PR has a descriptive title

## Breaking Changes

N/A

## Additional Notes

- Confirmation requires typing exact app name (not just "yes")
- Warning displayed if app is currently running
- `--force` flag skips all confirmations and deletes everything (useful for scripting)
- Data deletion is optional when using interactive mode
- Resources removed:
  - App container (`flaase-<app>-web`)
  - Database container (`flaase-<app>-db`) if configured
  - Cache container (`flaase-<app>-cache`) if configured
  - Docker volumes (if user confirms)
  - Docker network (`flaase-<app>`)
  - Traefik config (`/opt/flaase/traefik/dynamic/<app>.yml`)
  - App directory (`/opt/flaase/apps/<app>/`)
- Operation is irreversible — data cannot be recovered after volume deletion